### PR TITLE
proto: Add RTCM3 frame

### DIFF
--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PROTO_FILES
     synapse_pb/pose.proto
     synapse_pb/pwm.proto
     synapse_pb/quaternion.proto
+    synapse_pb/rtcm3.proto
     synapse_pb/safety.proto
     synapse_pb/sim_clock.proto
     synapse_pb/status.proto

--- a/proto/synapse_pb/frame.proto
+++ b/proto/synapse_pb/frame.proto
@@ -19,6 +19,7 @@ import "synapse_pb/pixart_paa3905.proto";
 import "synapse_pb/pose.proto";
 import "synapse_pb/pwm.proto";
 import "synapse_pb/quaternion.proto";
+import "synapse_pb/rtcm3.proto";
 import "synapse_pb/safety.proto";
 import "synapse_pb/sim_clock.proto";
 import "synapse_pb/status.proto";
@@ -69,5 +70,8 @@ message Frame
 
 		// simulation
 		SimClock sim_clock = 70;
+
+		// rtcm3
+		Rtcm3 rtcm3 = 80;
 	}
 }

--- a/proto/synapse_pb/rtcm3.options
+++ b/proto/synapse_pb/rtcm3.options
@@ -1,0 +1,1 @@
+synapse_pb.Rtcm3.data max_size:1030

--- a/proto/synapse_pb/rtcm3.proto
+++ b/proto/synapse_pb/rtcm3.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package synapse_pb;
+
+message Rtcm3 {
+	bytes data = 1;
+}

--- a/python/build.py
+++ b/python/build.py
@@ -52,6 +52,7 @@ def main():
         "pose.proto",
         "pwm.proto",
         "quaternion.proto",
+        "rtcm3.proto",
         "safety.proto",
         "sim_clock.proto",
         "status.proto",

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -35,6 +35,7 @@ fn main() -> std::io::Result<()> {
         "pose.proto",
         "pwm.proto",
         "quaternion.proto",
+        "rtcm3.proto",
         "safety.proto",
         "sim_clock.proto",
         "status.proto",

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -42,6 +42,7 @@ set(PROTO_FILES
     ${PROTO_DIR}/pose.proto
     ${PROTO_DIR}/pwm.proto
     ${PROTO_DIR}/quaternion.proto
+    ${PROTO_DIR}/rtcm3.proto
     ${PROTO_DIR}/safety.proto
     ${PROTO_DIR}/sim_clock.proto
     ${PROTO_DIR}/status.proto


### PR DESCRIPTION
Generic frame to be used as pass-through by the RTK subsystem.